### PR TITLE
Feature: replaces rollup-stream with pure rollup configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "autoprefixer": "^9.3.1",
     "cssnano": "^4.1.7",
-    "glob": "^7.1.3",
+    "fast-glob": "^2.2.4",
     "gulp-file": "^0.4.0",
     "gulp-imagemin": "^5.0.3",
     "gulp-postcss": "^8.0.0",
@@ -52,15 +52,12 @@
     "gulp-sass-glob": "^1.0.9",
     "gulp-sourcemaps": "^2.6.4",
     "imagemin-jpegoptim": "^6.0.0",
-    "merge-stream": "^1.0.1",
     "node-notifier": "^5.3.0",
+    "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-resolve": "^3.4.0",
-    "rollup-plugin-uglify": "^6.0.0",
-    "rollup-stream": "^1.24.1",
-    "vinyl-buffer": "^1.0.1",
-    "vinyl-source-stream": "^2.0.0"
+    "rollup-plugin-uglify": "^6.0.0"
   }
 }


### PR DESCRIPTION
Resolves #16 

- Removes rollup-stream
- Removes glob
- Removes merge-stream
- Removes vinyl-source-stream
- Removes vinyl-buffer

- Adds Rollup
- Adds Fast-Glob - replacement for node-glob with better performance and simpler async interface
- Leverages gulp 4's ability to consume promises instead of streams with zero interface changes