### PR TITLE
Feature: sass imports ~ resolves to node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const path = require('path');
 // Style dependencies
 const sass = require('gulp-sass');
 const sassGlob = require('gulp-sass-glob');
+const tildeImporter = require('node-sass-tilde-importer');
 const postcss = require('gulp-postcss');
 const autoPrefixer = require('autoprefixer');
 const cssNano = require('cssnano');
@@ -78,7 +79,7 @@ const styles = () => {
 
     stream = stream
         .pipe(sassGlob())
-        .pipe(sass({ includePaths: ['./node_modules/**/'] }))
+        .pipe(sass({ importer: tildeImporter }))
         .on('error', err => {
             notification('styles', err);
         })

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "imagemin-jpegoptim": "^6.0.0",
     "merge-stream": "^1.0.1",
     "node-notifier": "^5.3.0",
+    "node-sass-tilde-importer": "^1.0.2",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-builtins": "^2.1.2",


### PR DESCRIPTION
Resolves #14 

Importing SCSS partials from node installed modules no longer requires absolute path to the node modules folder and allows you to prefix it with a ~ for folder resolution to the top level node_modules folder.